### PR TITLE
Changed scripts to point to the jar file that runs in Java 7.

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 evalb=../EVALB/evalb
 evalb_param=../EVALB/new.prm
-jarfile=../lib/BerkeleyParser-1.7.jar
+jarfile=../lib/BerkeleyParser-ppaml-1.8.jar
 grammar=eng_MLE
 
 .SECONDARY: data/sample_test.txt data/sample_gold.txt data/sample_pred.txt $(grammar).read.gr $(grammar).gr

--- a/eval.sh
+++ b/eval.sh
@@ -53,7 +53,7 @@ fi
 evalb=EVALB/evalb 
 evalb_param=EVALB/new.prm
 
-jarfile=lib/BerkeleyParser-1.7.jar
+jarfile=lib/BerkeleyParser-ppaml-1.8.jar
 
 # read and dump grammar object
 echo "Reading grammar ..."

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ log_path=$4
 
 mkdir -p "$output_dir"
 
-jarfile=$(readlink -m lib/BerkeleyParser-1.7.jar)
+jarfile=$(readlink -m lib/BerkeleyParser-ppaml-1.8.jar)
 grammar=pcfgla
 
 


### PR DESCRIPTION
Any reason not to make it the default?